### PR TITLE
Eval block for Eigen 3.4 compatibility

### DIFF
--- a/inst/include/svines/implementation/svine_selector.ipp
+++ b/inst/include/svines/implementation/svine_selector.ipp
@@ -491,13 +491,13 @@ SVineStructureSelector::finalize(size_t trunc_lvl)
   if (d_ == cs_dim_) {
     trees_ = trees_opt_;
     auto mat = vine_struct_.get_matrix();
-    cs_struct_ = RVineStructure(mat.block(0, d_ - cs_dim_, cs_dim_, cs_dim_));
+    cs_struct_ = RVineStructure(mat.block(0, d_ - cs_dim_, cs_dim_, cs_dim_).eval());
     in_vertices_ = tools_stl::rev(cs_struct_.get_order());
     out_vertices_ = in_vertices_;
   } else {
     finalize_svine(trunc_lvl);
     auto mat = vine_struct_.get_matrix();
-    cs_struct_ = RVineStructure(mat.block(0, d_ - cs_dim_, cs_dim_, cs_dim_));
+    cs_struct_ = RVineStructure(mat.block(0, d_ - cs_dim_, cs_dim_, cs_dim_).eval());
   }
 }
 


### PR DESCRIPTION
This PR forces an evaluation in the construction of the `RVineStructure` objects in your C++ code, as there are changes to the templating in Eigen 3.4 that cause compilation errors in your package. Without this, your package will break with the next version of `RcppEigen`.

Let me know if you have any questions, thanks!